### PR TITLE
removal of bad min width statement on drawingboard

### DIFF
--- a/src/WebFrontEnd/ClientApp/src/app/shared/components/drawingboard/drawingboard.component.scss
+++ b/src/WebFrontEnd/ClientApp/src/app/shared/components/drawingboard/drawingboard.component.scss
@@ -5,7 +5,6 @@
 
 .drawb-canvas {
     flex-basis: 65%;
-    min-width: 500px;
 }
 
 .radio-group {


### PR DESCRIPTION
not sure how this css statement got back in, but needs to be removed.